### PR TITLE
Add support to play in external processgg

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,42 +8,56 @@
   <img src="https://github.com/squiter/ivy-youtube/blob/master/demo4.png">
 </p>
 
-Ivy-YouTube is a simple plugin to query YouTube via emacs and play videos in your browser. 
+Ivy-YouTube is a simple plugin to query YouTube via emacs and play videos in your browser.
 
 **IMPORTANT:** Remeber to set your 'ivy-youtube-key' variable!
 
 ## Based on Helm-Youtube
 
-This package was based on [Maximilian Roquemore](https://github.com/maximus12793)'s package called [helm-youtube](https://github.com/maximus12793/helm-youtube).  
+This package was based on [Maximilian Roquemore](https://github.com/maximus12793)'s package called [helm-youtube](https://github.com/maximus12793/helm-youtube).
 Thanks Maximilian to create this awesome package.
 
 
-## Installation 
-1. M-x package-install: ivy-youtube
+## Installation
 
-2. Obtain new google API key 
+The installation process is very simple:
+
+- M-x package-install: ivy-youtube
+- Obtain new google API key
     [here](https://console.developers.google.com/ "Google Developer Console")
 
     ![Screenshot](https://github.com/squiter/ivy-youtube/blob/master/api.png)
 
-3. **IMPORTANT:** Set 'ivy-youtube-key' variable
-
+- **IMPORTANT:** Set 'ivy-youtube-key' variable
 
     ``` el
     M-x customize-variable ;; search 'ivy-youtube-key'
     Ivy Youtube Key: replace "NONE" with "API KEY" ;; FROM STEP 2
     ```
 
-4. Set browse-url-generic and add to .emacs
+## Where do you want to play the video?
 
- 
-    ``` el
-    ;;start ivy-youtube.el
-    (autoload 'ivy-youtube "ivy-youtube" nil t)
-    (global-set-key (kbd "C-c y") 'ivy-youtube) ;; bind hotkey
+By default Ivy Youtube play the selected video in your default browser, but you can configure that:
 
-    ;;set default browser for you will use to play videos/default generic
-    (setq browse-url-browser-function 'browse-url-generic)
-    (setq browse-url-generic-program "google-chrome-open-url")
-    ```
-5. Enjoy :) 
+### Change the default brownser:
+
+Set browse-url-generic and add to .emacs
+
+``` elisp
+;;start ivy-youtube.el
+(autoload 'ivy-youtube "ivy-youtube" nil t)
+(global-set-key (kbd "C-c y") 'ivy-youtube) ;; bind hotkey
+
+;;set default browser for you will use to play videos/default generic
+(setq browse-url-browser-function 'browse-url-generic)
+(setq browse-url-generic-program "google-chrome-open-url")
+```
+
+### Using an external player (beta)
+
+You can set a external player to watch your videos, like `mpv` or
+`vlc`. To do that you need to set the custom varialble
+`ivy-youtube-play-at`: `M-x
+customize-variable<RET>ivy-youtube-play-at<RET>`.
+You can set in this field any binary that receives the youtube url as
+parameter like: `/usr/bin/mpv` or `/usr/bin/vlc`.

--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -107,13 +107,17 @@
 
 (defun ivy-youtube-play-on-process (video-url)
   "Start a process based on ivy-youtube-play-at variable passing VIDEO-URL."
-  (message "Starting a process...")
-  (start-process "Ivy Youtube Process" nil ivy-youtube-play-at video-url))
+  (message (format "Starting a process with: [%s %s]" ivy-youtube-play-at video-url))
+  (make-process :name "Ivy Youtube"
+                :buffer "*Ivy Youtube Output*"
+                :sentinel (lambda (process event)
+                            (message
+                             (format "Ivy Youtube: Process %s (Check buffer *Ivy Youtube Output*)" event)))
+                :command `(,ivy-youtube-play-at ,video-url)))
 
 (defun ivy-youtube-build-url (video-id)
   "Create a usable youtube URL with VIDEO-ID."
   (concat "http://www.youtube.com/watch?v=" video-id))
-
 
 (defun ivy-youtube-wrapper (*qqJson*)
   "Parse the json provided by *QQJSON* and provide search result targets."

--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -3,11 +3,11 @@
 ;; Copyright (C) 2017 Brunno dos Santos
 
 ;; Author: Brunno dos Santos
-;; Version: 1.0
+;; Version: 1.1
 ;; Package-Requires: ((request "0.2.0") (ivy "0.8.0") (cl-lib "0.5"))
 ;; URL: https://github.com/squiter/ivy-youtube
 ;; Created: 2017-Jan-02
-;; Keywords: youtube, multimedia
+;; Keywords: youtube, multimedia, mpv, vlc
 
 ;;; Commentary:
 
@@ -54,7 +54,13 @@
 
 (defcustom ivy-youtube-key nil
   "Your Google API key.";; INSERT YOUR KEY FROM GOOGLE ACCOUNT!!!
+  :type '(string)
   :group 'ivy-youtube)
+
+(defcustom ivy-youtube-play-at "browser"
+  "Where do you want to play the video.  You can set browser or process."
+  :type '(string)
+  :group 'ivy-youtube-play-at)
 
 ;;;###autoload
 (defun ivy-youtube()
@@ -84,10 +90,29 @@
       (if (eql x key) tree
 	(or (ivy-youtube-tree-assoc key x) (ivy-youtube-tree-assoc key y))))))
 
-(defun ivy-youtube-playvideo (video-id)
-  "Format the youtube URL via VIDEO-ID."
-  (browse-url
-   (concat "http://www.youtube.com/watch?v=" video-id)))
+(defun ivy-youtube-playvideo (video-url)
+  "Play the video based on users choice."
+  (cond ((equal ivy-youtube-play-at "browser")
+         (ivy-youtube-play-on-browser video-url))
+        ((equal ivy-youtube-play-at nil)
+         (ivy-youtube-play-on-browser video-url))
+        ((equal ivy-youtube-play-at "")
+         (ivy-youtube-play-on-browser video-url))
+        (t (ivy-youtube-play-on-process video-url))))
+
+(defun ivy-youtube-play-on-browser (video-url)
+  "Open your browser with VIDEO-URL."
+  (message "Opening your video on browser...")
+  (browse-url video-url))
+
+(defun ivy-youtube-play-on-process (video-url)
+  "Start a process based on ivy-youtube-play-at variable passing VIDEO-URL."
+  (message "Starting a process...")
+  (start-process "Ivy Youtube Process" nil ivy-youtube-play-at video-url))
+
+(defun ivy-youtube-build-url (video-id)
+  "Create a usable youtube URL with VIDEO-ID."
+  (concat "http://www.youtube.com/watch?v=" video-id))
 
 
 (defun ivy-youtube-wrapper (*qqJson*)
@@ -99,7 +124,7 @@
     (ivy-read "Youtube Search Results"
               *results*
               :action (lambda (cand)
-                        (ivy-youtube-playvideo (cdr cand))))))
+                        (ivy-youtube-playvideo (ivy-youtube-build-url (cdr cand)))))))
 
 (provide 'ivy-youtube)
 


### PR DESCRIPTION
# Motivation

We need to let the user chose where he want to watch your video. This PR fix the #1 

# Proposed Solution

Add a custom variable that receive an external program to run the seletected video, E.g. `/usr/bin/mpv` or `/usr/bin/vlc`.

I tested this branch with MPV and VLC.