### PR TITLE
Handle 403 errors and teach how to create a YouTube API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ The installation process is very simple:
 
     ![Screenshot](https://github.com/squiter/ivy-youtube/blob/master/api.png)
 
+    - To create this API key you need to go to `Credentials` ->
+      `Create Credentials` and select `API Key`
+    - After create you need to **enable** it: go to `Library`, select
+      `YouTube Data API` and click in `Enable` button on top.
+
 - **IMPORTANT:** Set 'ivy-youtube-key' variable
 
     ``` el

--- a/contributing.json
+++ b/contributing.json
@@ -19,7 +19,7 @@
     "subject_must_not_end_with_dot": true,
 
     "body_cannot_be_empty": true,
-    "body_must_include_verification_steps": true
+    "body_must_include_verification_steps": false
   },
   "issue": {
     "subject_cannot_be_empty": true,

--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2017 Brunno dos Santos
 
 ;; Author: Brunno dos Santos
-;; Version: 0.3.0
+;; Version: 0.3.1
 ;; Package-Requires: ((request "0.2.0") (ivy "0.8.0") (cl-lib "0.5"))
 ;; URL: https://github.com/squiter/ivy-youtube
 ;; Created: 2017-Jan-02
@@ -91,7 +91,9 @@
 	       (ivy-youtube-wrapper data)));;function
    :status-code '((400 . (lambda (&rest _) (message "Got 400.")))
 		  ;; (200 . (lambda (&rest _) (message "Got 200.")))
-		  (418 . (lambda (&rest _) (message "Got 418."))))
+		  (418 . (lambda (&rest _) (message "Got 418.")))
+                  (403 . (lambda (&rest _)
+                           (message "403: Unauthorized. Maybe you need to enable your youtube api key"))))
    :complete (message "searching...")))
 
 (defun ivy-youtube-tree-assoc (key tree)


### PR DESCRIPTION
This PR handles the 403 error message that Youtube API raises when you try to search using a disabled API key.

This PR resolves #5  