### PR TITLE
Fix invalid function call

### DIFF
--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -70,11 +70,11 @@
 (defun ivy-youtube-history-list ()
   "Return a list with content of file or an empty list."
   (if (file-readable-p ivy-youtube-history-file)
-      (read-lines ivy-youtube-history-file)
+      (vc--read-lines ivy-youtube-history-file)
     '()))
 
 ;;;###autoload
-(defun ivy-youtube()
+(defun ivy-youtube ()
   (interactive)
   (unless ivy-youtube-key
     (error "You must set `ivy-youtube-key' to use this command"))

--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -67,10 +67,16 @@
   :type '(string)
   :group 'ivy-youtube)
 
+(defun ivy-youtube-read-lines (filePath)
+  "Return a list of lines of a file at FILEPATH."
+  (with-temp-buffer
+    (insert-file-contents filePath)
+    (split-string (buffer-string) "\n" t)))
+
 (defun ivy-youtube-history-list ()
   "Return a list with content of file or an empty list."
   (if (file-readable-p ivy-youtube-history-file)
-      (vc--read-lines ivy-youtube-history-file)
+      (ivy-youtube-read-lines ivy-youtube-history-file)
     '()))
 
 ;;;###autoload


### PR DESCRIPTION
Modify undefined function call 'read-lines' to 'vc--read-lines', which fixes the error when calling ivy-youtube with search history.