### PR TITLE
Added option to change max search results

### DIFF
--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -67,6 +67,13 @@
   :type '(string)
   :group 'ivy-youtube)
 
+(defcustom ivy-youtube-max-results 20
+  "The max amount of results displayed after search
+
+Increasing this value too much might result in getting connection errors"
+  :type '(integer)
+  :group 'ivy-youtube)
+
 (defun ivy-youtube-read-lines (filePath)
   "Return a list of lines of a file at FILEPATH."
   (with-temp-buffer
@@ -89,7 +96,7 @@
    :params `(("part" . "snippet")
 	     ("q" . ,(ivy-youtube-search))
 	     ("type" . "video")
-	     ("maxResults" . "20")
+	     ("maxResults" . ,(int-to-string ivy-youtube-max-results))
 	     ("key" .  ,ivy-youtube-key));; <--- GOOGLE API KEY
    :parser 'json-read
    :success (cl-function

--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -67,7 +67,7 @@
   :type '(string)
   :group 'ivy-youtube)
 
-(defcustom ivy-youtube-max-results 20
+(defcustom ivy-youtube-max-results 50
   "The max amount of results displayed after search
 
 Increasing this value too much might result in getting connection errors"


### PR DESCRIPTION
As far as i can see there isn't a hard-limit on 20 results per search, I've been able to get as many as 50 results per search without getting an error. This adds an option to customize this variable.
EDIT: 50 is the hard-limit right now https://developers.google.com/youtube/v3/docs/search/list