### PR TITLE
Results seem to be in reverse order

### DIFF
--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -147,7 +147,7 @@ If nil then don't keep a search history"
              do (push (cons (cdr (ivy-youtube-tree-assoc 'title x))
                             (cdr (ivy-youtube-tree-assoc 'videoId x))) *results*))
     (ivy-read "Youtube Search Results"
-              *results*
+              (reverse *results*)
               :action (lambda (cand)
                         (ivy-youtube-playvideo (ivy-youtube-build-url (cdr cand)))))))
 


### PR DESCRIPTION
The search results seem to be in the reverse order
You can see that the results are more accurate in the second screenshot 
The only downside to this is that the first entry will be a `nil` because of some bug that I will create a issue on later (it's present in all ivy-youtube versions, but it's normally pretty well hidden at the bottom).
This is identical on pretty much every version of `ivy-youtube` (initial commit, before my recent changes, master)
I'm using `emacs -q` here

![ivy-youtube-filter](https://user-images.githubusercontent.com/2865774/47721045-8b284780-dc4f-11e8-8fc5-dec887c06c80.png)
Before reversing order
![ivy-youtube-not-reversed](https://user-images.githubusercontent.com/2865774/47721196-e0645900-dc4f-11e8-9a44-85ae2628fcf1.png)
After reversing order
![ivy-youtube-filter2](https://user-images.githubusercontent.com/2865774/47721089-a5622580-dc4f-11e8-8f2b-a86af843c6a2.png)

I will admit that the solution is kind of hacky though hah