### PR TITLE
First search entry showing nil fix

### DIFF
--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -145,8 +145,9 @@ If nil then don't keep a search history"
   (let (results '())
     (let ((search-results (cdr (ivy-youtube-tree-assoc 'items *qqJson*))))
       (dotimes (i (length search-results))
-	(add-to-list 'results (cons (cdr (ivy-youtube-tree-assoc 'title (aref search-results i)))
-				    (cdr (ivy-youtube-tree-assoc 'videoId (aref search-results i)))))))
+	(push  (cons (cdr (ivy-youtube-tree-assoc 'title (aref search-results i)))
+		     (cdr (ivy-youtube-tree-assoc 'videoId (aref search-results i))))
+	       results)))
     (ivy-read "Youtube Search Results"
               (reverse results)
               :action (lambda (cand)

--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -147,7 +147,7 @@ If nil then don't keep a search history"
              do (push (cons (cdr (ivy-youtube-tree-assoc 'title x))
                             (cdr (ivy-youtube-tree-assoc 'videoId x))) *results*))
     (ivy-read "Youtube Search Results"
-              *results*
+              (reverse *results*)
               :action (lambda (cand)
                         (ivy-youtube-playvideo (ivy-youtube-build-url (cdr cand)))))))
 

--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -142,12 +142,13 @@ If nil then don't keep a search history"
 
 (defun ivy-youtube-wrapper (*qqJson*)
   "Parse the json provided by *QQJSON* and provide search result targets."
-  (let (*results* '())
-    (cl-loop for x being the elements of (ivy-youtube-tree-assoc 'items *qqJson*)
-             do (push (cons (cdr (ivy-youtube-tree-assoc 'title x))
-                            (cdr (ivy-youtube-tree-assoc 'videoId x))) *results*))
+  (let (results '())
+    (let ((search-results (cdr (ivy-youtube-tree-assoc 'items *qqJson*))))
+      (dotimes (i (length search-results))
+	(add-to-list 'results (cons (cdr (ivy-youtube-tree-assoc 'title (aref search-results i)))
+				    (cdr (ivy-youtube-tree-assoc 'videoId (aref search-results i)))))))
     (ivy-read "Youtube Search Results"
-              (reverse *results*)
+              (reverse results)
               :action (lambda (cand)
                         (ivy-youtube-playvideo (ivy-youtube-build-url (cdr cand)))))))
 


### PR DESCRIPTION
#15 Is now fixed! I just rewrote the `cl-loop` I talked about in #15 without cl. I couldn't find a function that iterated over an array so I just used a simple `dotimes` and then got the `nth` entry.