### PR TITLE
Add spacing to search prompt

### DIFF
--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -162,7 +162,7 @@ Increasing this value too much might result in getting connection errors"
 
 (defun ivy-youtube-search ()
   "Use ivy-read to select your search history."
-  (ivy-read "Search YouTube:"
+  (ivy-read "Search YouTube: "
             (ivy-youtube-history-list)
             :action (lambda (cand)
                       (ivy-youtube-append-history cand))))


### PR DESCRIPTION
Make search prompt in line with the rest of ivy tools