### PR TITLE
Fix process sentinel error after search is complete

### DIFF
--- a/ivy-youtube.el
+++ b/ivy-youtube.el
@@ -109,7 +109,9 @@ Increasing this value too much might result in getting connection errors"
 		  (418 . (lambda (&rest _) (message "Got 418.")))
                   (403 . (lambda (&rest _)
                            (message "403: Unauthorized. Maybe you need to enable your youtube api key"))))
-   :complete (message "searching...")))
+   :complete (cl-function
+              (lambda (&rest args)
+                (message "Search finished")))))
 
 (defun ivy-youtube-tree-assoc (key tree)
   "Build the tree-assoc from KEY TREE for youtube query."


### PR DESCRIPTION
After doing a successful search of a YT video I get the following error on Emacs 27.1:

> error in process sentinel: Invalid function: "searching..."

It seems that `request` is expecting a function for the :complete keyword argument on `ivy-youtube`.